### PR TITLE
Add HTTP-Redirect binding to app metadata

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -24,3 +24,7 @@ export function appIdpRedirectUrl(app: App): string {
 export function appIdpMetadataUrl(app: App): string {
   return `https://${process.env.DUMMYIDP_CUSTOM_DOMAIN || process.env.VERCEL_URL}/apps/${app.id}/metadata`;
 }
+
+export function appLoginUrl(app: App): string {
+  return `https://${process.env.DUMMYIDP_CUSTOM_DOMAIN || process.env.VERCEL_URL}/apps/${app.id}/login`;
+}

--- a/src/app/apps/[id]/metadata/route.ts
+++ b/src/app/apps/[id]/metadata/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getApp } from "@/app/actions";
-import { appIdpEntityId, appIdpRedirectUrl } from "@/app/app";
+import { appIdpEntityId, appIdpRedirectUrl, appLoginUrl } from "@/app/app";
 import { INSECURE_PUBLIC_CERTIFICATE } from "@/lib/insecure-cert";
 
 export async function GET(
@@ -30,6 +30,7 @@ export async function GET(
     </md:KeyDescriptor>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="${appIdpRedirectUrl(app!)}"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="${appLoginUrl(app!)}"/>
   </md:IDPSSODescriptor>
 </md:EntityDescriptor>`,
     {


### PR DESCRIPTION
This PR adds a HTTP-Redirect binding to the metadata for apps. The login page already implements that binding, so this PR just uses that as the HTTP-Redirect location.

Closes #10.