### PR TITLE
lib/saml: fix base64 encoding of SAML assertions for users with non-ASCII names

### DIFF
--- a/src/lib/saml.ts
+++ b/src/lib/saml.ts
@@ -14,7 +14,9 @@ export async function encodeAssertion(
   key: CryptoKey,
   assertionData: AssertionData,
 ): Promise<string> {
-  return btoa(await signAssertion(key, assertionData));
+  // naively calling btoa does not correctly handle non-ASCII
+  const payload = await signAssertion(key, assertionData);
+  return btoa(String.fromCharCode(...new TextEncoder().encode(payload)));
 }
 
 async function signAssertion(


### PR DESCRIPTION
This PR fixes `encodeAssertion` to use btoa correctly for SAML assertions that contain non-ASCII. 

Messages are first manually encoded into UTF-8, and the resulting data is coerced into a JS string that btoa will correctly encode. That intermediary string isn't entirely meaningful -- JS strings are UTF-16, not UTF-8 -- but I think this "hack" of sorts is tolerable given how fleeting its use is.